### PR TITLE
Added CSS to known extensions for files directory

### DIFF
--- a/files/.htaccess
+++ b/files/.htaccess
@@ -1,6 +1,6 @@
 # Force plain text showing
 ForceType text/plain
-<FilesMatch "(?i)\.(gif|jpe?g|png|svg|zip|tgz|txt|md|docx?|pdf|xlsx?|pptx?|html?|mp4|webm|ogv|m4v|mp3|wav)$" >
+<FilesMatch "(?i)\.(gif|jpe?g|png|svg|zip|tgz|txt|md|docx?|pdf|xlsx?|pptx?|html?|css|mp4|webm|ogv|m4v|mp3|wav)$" >
   ForceType none
 </FilesMatch>
 


### PR DESCRIPTION
CSS files should be provided with the correct Content-Type from the files directory.
This can be useful e.g. for :
* theme creators (to allow users to upload/edit a small custom CSS file in the backend to manipulate some basic settings such as anchor color)
* authors can provide CSS-files to be used in other sites (e.g. [blog.fefe.de](https://blog.fefe.de/faq.html) offers the option to include a external css)

The change is necessary b.c. if the Content-Type does not match browsers will not use the CSS-file, see [here](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Configuring_server_MIME_types#Why_are_correct_MIME_types_important.3F)
